### PR TITLE
👌 OPTIM: Adding 'beapi.maintenance_mode.is_maintenance_mode' filter

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -17,7 +17,8 @@ class Helpers {
 	 * @return bool
 	 */
 	public static function is_maintenance_mode() {
-		return ! is_user_logged_in() && ! self::is_allowed_ip() && ! self::is_ms_activate();
+		$is_maintenance_mode = ! is_user_logged_in() && ! self::is_allowed_ip() && ! self::is_ms_activate();
+		return apply_filters( 'beapi.maintenance_mode.is_maintenance_mode', $is_maintenance_mode );
 	}
 
 	/**


### PR DESCRIPTION
This filter will give developers a way to customize the maintenance mode decision logic.

### Usage
```
<?php

namespace Something;

/**
 * Disable maintenance mode for logged-in users, except admins
 *
 * @param boolean $is_maintenance_mode
 * @return boolean
 */
function set_custom_maintenance_mode_activation( $is_maintenance_mode ) {
	if ( is_user_logged_in() && current_user_can( 'administrator' ) ) {
		return false;
	}

	return true;
}
add_filter( 'beapi.maintenance_mode.is_maintenance_mode', __NAMESPACE__ . '\\set_custom_maintenance_mode_activation' );
```