### PR TITLE
Getting the "__SELF__" warnings to go away by changing Helpers::maint…

### DIFF
--- a/classes/helpers.php
+++ b/classes/helpers.php
@@ -52,11 +52,11 @@ class Helpers {
 			// No current ip set to check against
 			return false;
 		}
-		$current_ip = preg_replace_callback( '/(\d+)/', [ __SELF__, 'maintenance_replace_ip' ], $current_ip );
+		$current_ip = preg_replace_callback( '/(\d+)/', [ 'BEAPI\Maintenance_Mode\Helpers', 'maintenance_replace_ip' ], $current_ip );
 
 		// Loop on each whitelist IP
 		foreach ( $whitelist_ips as $allowed_ip ) {
-			$allowed_ip = preg_replace_callback( '/(\d+)/', [ __SELF__, 'maintenance_replace_ip' ], $allowed_ip );
+			$allowed_ip = preg_replace_callback( '/(\d+)/', [ 'BEAPI\Maintenance_Mode\Helpers', 'maintenance_replace_ip' ], $allowed_ip );
 			// Not strict mode check because user ip and whitelist ips could not be the same type
 			if ( $current_ip == $allowed_ip ) {
 				// We found a match into the whitelist
@@ -94,7 +94,7 @@ class Helpers {
 	 *
 	 * @return string
 	 */
-	private function maintenance_replace_ip( $matches ) {
+	private static function maintenance_replace_ip( $matches ) {
 		return sprintf( "%03d", $matches[1] );
 	}
 


### PR DESCRIPTION
…enance_replace_ip() to a static function & changing the callable to use the full class name.

<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #9 .

It will apply the following changes :

* Helpers::maintenance_replace_ip() is now a static function (it is only called in one place, another static function, and does not need access to any instance properties).
* This allows us to change the callable to `[ 'BEAPI\Maintenance_Mode\Helpers', 'maintenance_replace_ip' ]` which does not create any warnings.

This is one way to solve this, I am open to any feedback/suggestions.

Thanks again for sharing a great plugin!